### PR TITLE
Handle missing usage in response

### DIFF
--- a/vlmrun/client/predictions.py
+++ b/vlmrun/client/predictions.py
@@ -132,6 +132,14 @@ class ImagePredictions(Predictions):
         )
         if not isinstance(response, dict):
             raise TypeError("Expected dict response")
+
+        if 'usage' not in response:
+            response['usage'] = {
+                'elements_processed': 0,
+                'element_type': 'image',
+                'credits_used': 0
+            }
+
         return PredictionResponse(**response)
 
 


### PR DESCRIPTION
Treat as zero-credit image workload.