### PR TITLE
By sending session id as request body, removed vlmrun[cli] compatibality issue as it used OpenAI client which did not support session id

### DIFF
--- a/vlmrun/cli/cli.py
+++ b/vlmrun/cli/cli.py
@@ -20,7 +20,7 @@ from vlmrun.cli._cli.predictions import app as predictions_app
 from vlmrun.cli._cli.config import app as config_app, get_config
 from vlmrun.cli._cli.chat import chat as chat_command
 from vlmrun.cli._cli.models import app as models_app
-from vlmrun.constants import DEFAULT_BASE_URL
+from vlmrun.constants import DEFAULT_AGENT_BASE_URL, DEFAULT_BASE_URL
 
 app = typer.Typer(
     name="vlmrun",
@@ -119,7 +119,11 @@ def main(
 
     if ctx.invoked_subcommand is not None:
         check_credentials(ctx, api_key, base_url)
-        ctx.obj = VLMRun(api_key=api_key, base_url=base_url)
+        # Chat subcommand uses the Agent API; use agent base URL when none set
+        client_base_url = base_url
+        if ctx.invoked_subcommand == "chat" and client_base_url is None:
+            client_base_url = DEFAULT_AGENT_BASE_URL
+        ctx.obj = VLMRun(api_key=api_key, base_url=client_base_url)
 
 
 # Add subcommands

--- a/vlmrun/constants.py
+++ b/vlmrun/constants.py
@@ -2,6 +2,8 @@ from pathlib import Path
 import os
 
 DEFAULT_BASE_URL = "https://api.vlm.run/v1"
+# Agent API base URL (used by the chat subcommand for OpenAI-compatible completions)
+DEFAULT_AGENT_BASE_URL = "https://agent.vlm.run/v1"
 
 # Cache directories - use VLMRUN_CACHE_DIR env var if set, otherwise default to ~/.vlmrun/cache
 VLMRUN_HOME = Path.home() / ".vlmrun"


### PR DESCRIPTION
Issue:
The CLI passes session_id to client.agent.completions.create(), but the OpenAI Python client doesn't accept session_id (it's a VLM Run–specific parameter).

Changes:
In _cli/chat.py, fixing to send session_id via extra_body when present. Adding a helper to pass session_id via extra_body. The OpenAI client accepts extra_body and merges it into the request body, so the VLM Run backend still receives session_id.


Before
<img width="780" height="437" alt="image" src="https://github.com/user-attachments/assets/3e2b0707-ec85-40a9-a85c-2cbf04e7fac6" />


After
<img width="1005" height="584" alt="image" src="https://github.com/user-attachments/assets/92c5af87-c30b-40e2-8e80-e8f929afbdd5" />
<img width="1033" height="402" alt="image" src="https://github.com/user-attachments/assets/181deb6f-0a57-4b14-9d63-8986600c127e" />
