### PR TITLE
feat: add --timeout flag to chat CLI command

### DIFF
--- a/vlmrun/cli/_cli/chat.py
+++ b/vlmrun/cli/_cli/chat.py
@@ -583,6 +583,11 @@ def chat(
         "-s",
         help="Session UUID for persisting chat history (stateful conversations).",
     ),
+    timeout: Optional[float] = typer.Option(
+        None,
+        "--timeout",
+        help="Timeout in seconds for the chat completion request (overrides client default).",
+    ),
 ) -> None:
     """Process images, videos, and documents with natural language."""
     # Get client from context
@@ -747,6 +752,7 @@ def chat(
                         messages=messages,
                         stream=False,
                         extra_body=extra_body,
+                        **({"timeout": timeout} if timeout is not None else {}),
                     )
             else:
                 # JSON output: no status messages, just make the API call
@@ -756,6 +762,7 @@ def chat(
                         messages=messages,
                         stream=False,
                         extra_body=extra_body,
+                        **({"timeout": timeout} if timeout is not None else {}),
                     )
 
             latency_s = time.time() - start_time
@@ -814,6 +821,7 @@ def chat(
                     messages=messages,
                     stream=True,
                     extra_body=extra_body,
+                    **({"timeout": timeout} if timeout is not None else {}),
                 )
 
                 # Collect streaming content and usage data


### PR DESCRIPTION
## Summary

Adds a `--timeout` option to the `vlmrun chat` CLI command, allowing users to override the default client timeout for chat completion requests. The `generate` and `execute` commands already supported `--timeout`; this brings `chat` to parity.

When `--timeout` is not specified, the client's default timeout is used (no behavior change). The timeout is forwarded to all three `completions.create()` call sites: non-streaming (rich output), non-streaming (JSON output), and streaming.

## Review & Testing Checklist for Human

- [ ] Verify the `timeout` parameter is correctly forwarded by the OpenAI SDK's `completions.create()` — it accepts a per-call `timeout` kwarg that overrides the client-level default
- [ ] Note that `chat` uses `Optional[float]` for timeout while `generate` and `execute` use `int`. This is intentional since the OpenAI SDK accepts `float`, but confirm this inconsistency is acceptable or if you'd prefer `int` for consistency
- [ ] Test with `vlmrun chat "hello" --timeout 10` and `vlmrun chat "hello"` (without flag) to confirm both paths work

### Notes
- The `**({...} if ... else {})` pattern avoids passing `timeout=None` to the OpenAI client, which would override the client-level default with `None` rather than falling back to it.

Link to Devin session: https://app.devin.ai/sessions/0ff51e3ca26b4005bf4471cb93954201
Requested by: @spillai
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-python-sdk/pull/181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
