### PR TITLE
feat: add Evaluations resource with read-only evaluation API support

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -756,7 +756,15 @@ def mock_client(monkeypatch):
             def __init__(self, client):
                 self._client = client
 
-            def list(self, limit=30, offset=0, order_by="created_at", descending=True, created_at_gte=None, created_at_lte=None):
+            def list(
+                self,
+                limit=30,
+                offset=0,
+                order_by="created_at",
+                descending=True,
+                created_at_gte=None,
+                created_at_lte=None,
+            ):
                 return EvaluationRunListResponse(
                     data=[
                         EvaluationRunResponse(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,13 +13,21 @@ from typer.testing import CliRunner
 from vlmrun.client.types import (
     CreditUsage,
     DatasetResponse,
+    EvaluationMetricsResponse,
+    EvaluationPreviewResponse,
+    EvaluationRunListResponse,
+    EvaluationRunResponse,
+    EvaluationSummaryStatsResponse,
+    EvaluationUniqueSourcesResponse,
     FileResponse,
     HubDomainInfo,
     HubInfoResponse,
     HubSchemaResponse,
     ModelInfo,
+    OptimizeSkillResponse,
     PredictionResponse,
     PresignedUrlResponse,
+    RerunSkillResponse,
     SkillDownloadResponse,
     SkillInfo,
 )
@@ -117,6 +125,7 @@ def mock_client(monkeypatch):
             self.agent = self.Agent(self)
             self.artifacts = self.Artifacts(self)
             self.skills = self.Skills(self)
+            self.evaluations = self.Evaluations(self)
 
         class Skills:
             def __init__(self, client):
@@ -741,6 +750,95 @@ def mock_client(monkeypatch):
                     completed_at=datetime.fromisoformat("2024-01-01T00:00:01+00:00"),
                     response={"result": "execution result"},
                     usage=CreditUsage(credits_used=50),
+                )
+
+        class Evaluations:
+            def __init__(self, client):
+                self._client = client
+
+            def list(self, limit=30, offset=0, order_by="created_at", descending=True, created_at_gte=None, created_at_lte=None):
+                return EvaluationRunListResponse(
+                    data=[
+                        EvaluationRunResponse(
+                            id="eval-run-1",
+                            source_type="skill",
+                            source_label="invoice-parsing",
+                            status="completed",
+                            accuracy=0.95,
+                            total_items=100,
+                            total_with_feedback=50,
+                            created_at="2024-01-01T00:00:00+00:00",
+                        )
+                    ],
+                    count=1,
+                )
+
+            def get(self, run_id):
+                return EvaluationRunResponse(
+                    id=run_id,
+                    source_type="skill",
+                    source_label="invoice-parsing",
+                    status="completed",
+                    accuracy=0.95,
+                    total_items=100,
+                    total_with_feedback=50,
+                    created_at="2024-01-01T00:00:00+00:00",
+                )
+
+            def run(self, source_type, source_id, source_label, **kwargs):
+                return EvaluationRunResponse(
+                    id="eval-run-new",
+                    source_type=source_type,
+                    source_id=source_id,
+                    source_label=source_label,
+                    status="pending",
+                    created_at="2024-01-01T00:00:00+00:00",
+                )
+
+            def preview(self, source_type, source_id, data_from=None, data_to=None):
+                return EvaluationPreviewResponse(
+                    total_items=100,
+                    total_with_feedback=50,
+                    feedback_with_corrections=30,
+                    latest_item_at="2024-01-01T00:00:00+00:00",
+                )
+
+            def metrics(self, limit=20, source_type=None, source_label=None):
+                return EvaluationMetricsResponse(
+                    accuracy_trend=[],
+                    field_accuracies=[],
+                    latency_trend=[],
+                    avg_accuracy=0.92,
+                )
+
+            def summary_stats(self):
+                return EvaluationSummaryStatsResponse(
+                    total_runs=10,
+                    source_type_counts=[],
+                )
+
+            def unique_sources(self):
+                return EvaluationUniqueSourcesResponse(sources=[])
+
+            def delete(self, run_id):
+                return None
+
+            def optimize_skill(self, skill_id, **kwargs):
+                return OptimizeSkillResponse(
+                    skill_id="new-skill-id",
+                    name="invoice-parsing-optimized",
+                    version="20240102-abcd1234",
+                    original_skill_id=skill_id,
+                    total_pairs=100,
+                    sampled_pairs=50,
+                    created_at="2024-01-02T00:00:00+00:00",
+                )
+
+            def rerun_skill(self, evaluation_id, **kwargs):
+                return RerunSkillResponse(
+                    evaluation_id=evaluation_id,
+                    skill_id="skill-123",
+                    status="pending",
                 )
 
         class Artifacts:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,10 +24,8 @@ from vlmrun.client.types import (
     HubInfoResponse,
     HubSchemaResponse,
     ModelInfo,
-    OptimizeSkillResponse,
     PredictionResponse,
     PresignedUrlResponse,
-    RerunSkillResponse,
     SkillDownloadResponse,
     SkillInfo,
 )
@@ -793,16 +791,6 @@ def mock_client(monkeypatch):
                     created_at="2024-01-01T00:00:00+00:00",
                 )
 
-            def run(self, source_type, source_id, source_label, **kwargs):
-                return EvaluationRunResponse(
-                    id="eval-run-new",
-                    source_type=source_type,
-                    source_id=source_id,
-                    source_label=source_label,
-                    status="pending",
-                    created_at="2024-01-01T00:00:00+00:00",
-                )
-
             def preview(self, source_type, source_id, data_from=None, data_to=None):
                 return EvaluationPreviewResponse(
                     total_items=100,
@@ -830,24 +818,6 @@ def mock_client(monkeypatch):
 
             def delete(self, run_id):
                 return None
-
-            def optimize_skill(self, skill_id, **kwargs):
-                return OptimizeSkillResponse(
-                    skill_id="new-skill-id",
-                    name="invoice-parsing-optimized",
-                    version="20240102-abcd1234",
-                    original_skill_id=skill_id,
-                    total_pairs=100,
-                    sampled_pairs=50,
-                    created_at="2024-01-02T00:00:00+00:00",
-                )
-
-            def rerun_skill(self, evaluation_id, **kwargs):
-                return RerunSkillResponse(
-                    evaluation_id=evaluation_id,
-                    skill_id="skill-123",
-                    status="pending",
-                )
 
         class Artifacts:
             def __init__(self, client):

--- a/tests/test_evaluations.py
+++ b/tests/test_evaluations.py
@@ -1,0 +1,101 @@
+"""Tests for evaluations operations."""
+
+from vlmrun.client.types import (
+    EvaluationMetricsResponse,
+    EvaluationPreviewResponse,
+    EvaluationRunListResponse,
+    EvaluationRunResponse,
+    EvaluationSummaryStatsResponse,
+    EvaluationUniqueSourcesResponse,
+    OptimizeSkillResponse,
+    RerunSkillResponse,
+)
+
+
+def test_list_evaluations(mock_client):
+    """Test listing evaluation runs."""
+    response = mock_client.evaluations.list(limit=10, offset=0)
+    assert isinstance(response, EvaluationRunListResponse)
+    assert response.count == 1
+    assert len(response.data) == 1
+    assert response.data[0].id == "eval-run-1"
+    assert response.data[0].source_type == "skill"
+
+
+def test_get_evaluation(mock_client):
+    """Test getting a specific evaluation run."""
+    response = mock_client.evaluations.get("eval-run-1")
+    assert isinstance(response, EvaluationRunResponse)
+    assert response.id == "eval-run-1"
+    assert response.status == "completed"
+    assert response.accuracy == 0.95
+
+
+def test_run_evaluation(mock_client):
+    """Test triggering a new evaluation run."""
+    response = mock_client.evaluations.run(
+        source_type="skill",
+        source_id="skill-123",
+        source_label="invoice-parsing",
+    )
+    assert isinstance(response, EvaluationRunResponse)
+    assert response.id == "eval-run-new"
+    assert response.source_type == "skill"
+    assert response.source_id == "skill-123"
+    assert response.status == "pending"
+
+
+def test_preview_evaluation(mock_client):
+    """Test getting evaluation preview data."""
+    response = mock_client.evaluations.preview(
+        source_type="skill",
+        source_id="skill-123",
+    )
+    assert isinstance(response, EvaluationPreviewResponse)
+    assert response.total_items == 100
+    assert response.total_with_feedback == 50
+    assert response.feedback_with_corrections == 30
+
+
+def test_evaluation_metrics(mock_client):
+    """Test getting evaluation metrics."""
+    response = mock_client.evaluations.metrics(limit=10)
+    assert isinstance(response, EvaluationMetricsResponse)
+    assert response.avg_accuracy == 0.92
+    assert isinstance(response.accuracy_trend, list)
+
+
+def test_evaluation_summary_stats(mock_client):
+    """Test getting evaluation summary stats."""
+    response = mock_client.evaluations.summary_stats()
+    assert isinstance(response, EvaluationSummaryStatsResponse)
+    assert response.total_runs == 10
+
+
+def test_evaluation_unique_sources(mock_client):
+    """Test getting unique evaluation sources."""
+    response = mock_client.evaluations.unique_sources()
+    assert isinstance(response, EvaluationUniqueSourcesResponse)
+    assert isinstance(response.sources, list)
+
+
+def test_delete_evaluation(mock_client):
+    """Test deleting an evaluation run."""
+    result = mock_client.evaluations.delete("eval-run-1")
+    assert result is None
+
+
+def test_optimize_skill(mock_client):
+    """Test skill optimization."""
+    response = mock_client.evaluations.optimize_skill(skill_id="skill-123")
+    assert isinstance(response, OptimizeSkillResponse)
+    assert response.original_skill_id == "skill-123"
+    assert response.name == "invoice-parsing-optimized"
+
+
+def test_rerun_skill(mock_client):
+    """Test evaluation re-run."""
+    response = mock_client.evaluations.rerun_skill(evaluation_id="eval-run-1")
+    assert isinstance(response, RerunSkillResponse)
+    assert response.evaluation_id == "eval-run-1"
+    assert response.status == "pending"

--- a/tests/test_evaluations.py
+++ b/tests/test_evaluations.py
@@ -7,8 +7,6 @@ from vlmrun.client.types import (
     EvaluationRunResponse,
     EvaluationSummaryStatsResponse,
     EvaluationUniqueSourcesResponse,
-    OptimizeSkillResponse,
-    RerunSkillResponse,
 )
 
 
@@ -29,20 +27,6 @@ def test_get_evaluation(mock_client):
     assert response.id == "eval-run-1"
     assert response.status == "completed"
     assert response.accuracy == 0.95
-
-
-def test_run_evaluation(mock_client):
-    """Test triggering a new evaluation run."""
-    response = mock_client.evaluations.run(
-        source_type="skill",
-        source_id="skill-123",
-        source_label="invoice-parsing",
-    )
-    assert isinstance(response, EvaluationRunResponse)
-    assert response.id == "eval-run-new"
-    assert response.source_type == "skill"
-    assert response.source_id == "skill-123"
-    assert response.status == "pending"
 
 
 def test_preview_evaluation(mock_client):
@@ -83,19 +67,3 @@ def test_delete_evaluation(mock_client):
     """Test deleting an evaluation run."""
     result = mock_client.evaluations.delete("eval-run-1")
     assert result is None
-
-
-def test_optimize_skill(mock_client):
-    """Test skill optimization."""
-    response = mock_client.evaluations.optimize_skill(skill_id="skill-123")
-    assert isinstance(response, OptimizeSkillResponse)
-    assert response.original_skill_id == "skill-123"
-    assert response.name == "invoice-parsing-optimized"
-
-
-def test_rerun_skill(mock_client):
-    """Test evaluation re-run."""
-    response = mock_client.evaluations.rerun_skill(evaluation_id="eval-run-1")
-    assert isinstance(response, RerunSkillResponse)
-    assert response.evaluation_id == "eval-run-1"
-    assert response.status == "pending"

--- a/vlmrun/client/client.py
+++ b/vlmrun/client/client.py
@@ -25,6 +25,7 @@ from vlmrun.client.agent import Agent
 from vlmrun.client.skills import Skills
 from vlmrun.client.executions import Executions
 from vlmrun.client.artifacts import Artifacts
+from vlmrun.client.evaluations import Evaluations
 from vlmrun.constants import DEFAULT_BASE_URL
 from vlmrun.client.types import SchemaResponse, DomainInfo, GenerationConfig
 from vlmrun.client.exceptions import (
@@ -122,6 +123,7 @@ class VLMRun:
         self.skills = Skills(self)
         self.executions = Executions(self)
         self.artifacts = Artifacts(self)
+        self.evaluations = Evaluations(self)
 
     def __repr__(self):
         return f"VLMRun(base_url={self.base_url}, api_key={f'{self.api_key[:8]}...' if self.api_key else 'None'}, version={self.version})"

--- a/vlmrun/client/evaluations.py
+++ b/vlmrun/client/evaluations.py
@@ -12,8 +12,6 @@ from vlmrun.client.types import (
     EvaluationMetricsResponse,
     EvaluationSummaryStatsResponse,
     EvaluationUniqueSourcesResponse,
-    OptimizeSkillResponse,
-    RerunSkillResponse,
 )
 from vlmrun.types.abstract import VLMRunProtocol
 
@@ -79,61 +77,6 @@ class Evaluations:
         """
         response, status_code, headers = self._requestor.request(
             method="GET", url=f"evaluations/{run_id}"
-        )
-        return EvaluationRunResponse(**response)
-
-    def run(
-        self,
-        source_type: str,
-        source_id: str,
-        source_label: str,
-        execution_ids: list[str] | None = None,
-        request_ids: list[str] | None = None,
-        skill_ids: list[str] | None = None,
-        data_from: str | None = None,
-        data_to: str | None = None,
-        evaluators: list[str] | None = None,
-        infer_corrections: bool | None = None,
-    ) -> EvaluationRunResponse:
-        """Trigger a new evaluation run.
-
-        Args:
-            source_type: Type of evaluation source ("agent", "request_domain", or "skill")
-            source_id: ID of the source to evaluate
-            source_label: Display label for the source
-            execution_ids: Optional list of execution IDs to evaluate
-            request_ids: Optional list of request IDs to evaluate
-            skill_ids: Optional list of skill IDs to evaluate
-            data_from: Optional start datetime for data range (ISO format)
-            data_to: Optional end datetime for data range (ISO format)
-            evaluators: Optional list of evaluator types to use
-            infer_corrections: Whether to infer corrections from feedback
-
-        Returns:
-            EvaluationRunResponse: The created evaluation run
-        """
-        data: dict[str, Any] = {
-            "source_type": source_type,
-            "source_id": source_id,
-            "source_label": source_label,
-        }
-        if execution_ids is not None:
-            data["execution_ids"] = execution_ids
-        if request_ids is not None:
-            data["request_ids"] = request_ids
-        if skill_ids is not None:
-            data["skill_ids"] = skill_ids
-        if data_from is not None:
-            data["data_from"] = data_from
-        if data_to is not None:
-            data["data_to"] = data_to
-        if evaluators is not None:
-            data["evaluators"] = evaluators
-        if infer_corrections is not None:
-            data["infer_corrections"] = infer_corrections
-
-        response, status_code, headers = self._requestor.request(
-            method="POST", url="evaluations/run", data=data
         )
         return EvaluationRunResponse(**response)
 
@@ -225,75 +168,3 @@ class Evaluations:
             run_id: The evaluation run ID to delete
         """
         self._requestor.request(method="DELETE", url=f"evaluations/{run_id}")
-
-    def optimize_skill(
-        self,
-        skill_id: str,
-        skill_ids: list[str] | None = None,
-        data_from: str | None = None,
-        data_to: str | None = None,
-        infer_corrections: bool = True,
-        n_samples: int | None = None,
-    ) -> OptimizeSkillResponse:
-        """Optimize a skill based on evaluation data.
-
-        Args:
-            skill_id: The skill ID to optimize
-            skill_ids: Optional list of additional skill IDs
-            data_from: Optional start datetime for data range (ISO format)
-            data_to: Optional end datetime for data range (ISO format)
-            infer_corrections: Whether to infer corrections (default: True)
-            n_samples: Optional number of samples to use
-
-        Returns:
-            OptimizeSkillResponse: The optimization result
-        """
-        data: dict[str, Any] = {"skill_id": skill_id}
-        if skill_ids is not None:
-            data["skill_ids"] = skill_ids
-        if data_from is not None:
-            data["data_from"] = data_from
-        if data_to is not None:
-            data["data_to"] = data_to
-        data["infer_corrections"] = infer_corrections
-        if n_samples is not None:
-            data["n_samples"] = n_samples
-
-        response, status_code, headers = self._requestor.request(
-            method="POST", url="evaluations/optimize", data=data
-        )
-        return OptimizeSkillResponse(**response)
-
-    def rerun_skill(
-        self,
-        evaluation_id: str,
-        skill_id: str | None = None,
-        evaluators: list[str] | None = None,
-        infer_corrections: bool = True,
-        n_samples: int | None = None,
-    ) -> RerunSkillResponse:
-        """Re-run an evaluation with different parameters.
-
-        Args:
-            evaluation_id: The evaluation run ID to re-run
-            skill_id: Optional skill ID to use for the re-run
-            evaluators: Optional list of evaluator types to use
-            infer_corrections: Whether to infer corrections (default: True)
-            n_samples: Optional number of samples to use
-
-        Returns:
-            RerunSkillResponse: The re-run result
-        """
-        data: dict[str, Any] = {"evaluation_id": evaluation_id}
-        if skill_id is not None:
-            data["skill_id"] = skill_id
-        if evaluators is not None:
-            data["evaluators"] = evaluators
-        data["infer_corrections"] = infer_corrections
-        if n_samples is not None:
-            data["n_samples"] = n_samples
-
-        response, status_code, headers = self._requestor.request(
-            method="POST", url="evaluations/rerun", data=data
-        )
-        return RerunSkillResponse(**response)

--- a/vlmrun/client/evaluations.py
+++ b/vlmrun/client/evaluations.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from vlmrun.client.base_requestor import APIRequestor
 from vlmrun.client.types import (
@@ -36,8 +36,8 @@ class Evaluations:
         offset: int = 0,
         order_by: str = "created_at",
         descending: bool = True,
-        created_at_gte: Optional[str] = None,
-        created_at_lte: Optional[str] = None,
+        created_at_gte: str | None = None,
+        created_at_lte: str | None = None,
     ) -> EvaluationRunListResponse:
         """List evaluation runs with pagination and filtering.
 
@@ -52,7 +52,7 @@ class Evaluations:
         Returns:
             EvaluationRunListResponse: Paginated list of evaluation runs
         """
-        params: Dict[str, Any] = {
+        params: dict[str, Any] = {
             "limit": limit,
             "offset": offset,
             "order_by": order_by,
@@ -87,13 +87,13 @@ class Evaluations:
         source_type: str,
         source_id: str,
         source_label: str,
-        execution_ids: Optional[List[str]] = None,
-        request_ids: Optional[List[str]] = None,
-        skill_ids: Optional[List[str]] = None,
-        data_from: Optional[str] = None,
-        data_to: Optional[str] = None,
-        evaluators: Optional[List[str]] = None,
-        infer_corrections: Optional[bool] = None,
+        execution_ids: list[str] | None = None,
+        request_ids: list[str] | None = None,
+        skill_ids: list[str] | None = None,
+        data_from: str | None = None,
+        data_to: str | None = None,
+        evaluators: list[str] | None = None,
+        infer_corrections: bool | None = None,
     ) -> EvaluationRunResponse:
         """Trigger a new evaluation run.
 
@@ -112,7 +112,7 @@ class Evaluations:
         Returns:
             EvaluationRunResponse: The created evaluation run
         """
-        data: Dict[str, Any] = {
+        data: dict[str, Any] = {
             "source_type": source_type,
             "source_id": source_id,
             "source_label": source_label,
@@ -141,8 +141,8 @@ class Evaluations:
         self,
         source_type: str,
         source_id: str,
-        data_from: Optional[str] = None,
-        data_to: Optional[str] = None,
+        data_from: str | None = None,
+        data_to: str | None = None,
     ) -> EvaluationPreviewResponse:
         """Get a preview of available data for an evaluation source.
 
@@ -155,7 +155,7 @@ class Evaluations:
         Returns:
             EvaluationPreviewResponse: Preview of available evaluation data
         """
-        params: Dict[str, str] = {
+        params: dict[str, str] = {
             "source_type": source_type,
             "source_id": source_id,
         }
@@ -172,8 +172,8 @@ class Evaluations:
     def metrics(
         self,
         limit: int = 20,
-        source_type: Optional[str] = None,
-        source_label: Optional[str] = None,
+        source_type: str | None = None,
+        source_label: str | None = None,
     ) -> EvaluationMetricsResponse:
         """Get aggregated metrics across evaluation runs.
 
@@ -185,7 +185,7 @@ class Evaluations:
         Returns:
             EvaluationMetricsResponse: Aggregated evaluation metrics
         """
-        params: Dict[str, Any] = {"limit": limit}
+        params: dict[str, Any] = {"limit": limit}
         if source_type:
             params["source_type"] = source_type
         if source_label:
@@ -229,11 +229,11 @@ class Evaluations:
     def optimize_skill(
         self,
         skill_id: str,
-        skill_ids: Optional[List[str]] = None,
-        data_from: Optional[str] = None,
-        data_to: Optional[str] = None,
+        skill_ids: list[str] | None = None,
+        data_from: str | None = None,
+        data_to: str | None = None,
         infer_corrections: bool = True,
-        n_samples: Optional[int] = None,
+        n_samples: int | None = None,
     ) -> OptimizeSkillResponse:
         """Optimize a skill based on evaluation data.
 
@@ -248,7 +248,7 @@ class Evaluations:
         Returns:
             OptimizeSkillResponse: The optimization result
         """
-        data: Dict[str, Any] = {"skill_id": skill_id}
+        data: dict[str, Any] = {"skill_id": skill_id}
         if skill_ids is not None:
             data["skill_ids"] = skill_ids
         if data_from is not None:
@@ -267,10 +267,10 @@ class Evaluations:
     def rerun_skill(
         self,
         evaluation_id: str,
-        skill_id: Optional[str] = None,
-        evaluators: Optional[List[str]] = None,
+        skill_id: str | None = None,
+        evaluators: list[str] | None = None,
         infer_corrections: bool = True,
-        n_samples: Optional[int] = None,
+        n_samples: int | None = None,
     ) -> RerunSkillResponse:
         """Re-run an evaluation with different parameters.
 
@@ -284,7 +284,7 @@ class Evaluations:
         Returns:
             RerunSkillResponse: The re-run result
         """
-        data: Dict[str, Any] = {"evaluation_id": evaluation_id}
+        data: dict[str, Any] = {"evaluation_id": evaluation_id}
         if skill_id is not None:
             data["skill_id"] = skill_id
         if evaluators is not None:

--- a/vlmrun/client/evaluations.py
+++ b/vlmrun/client/evaluations.py
@@ -1,0 +1,299 @@
+"""VLM Run API Evaluations resource."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from vlmrun.client.base_requestor import APIRequestor
+from vlmrun.client.types import (
+    EvaluationRunResponse,
+    EvaluationRunListResponse,
+    EvaluationPreviewResponse,
+    EvaluationMetricsResponse,
+    EvaluationSummaryStatsResponse,
+    EvaluationUniqueSourcesResponse,
+    OptimizeSkillResponse,
+    RerunSkillResponse,
+)
+from vlmrun.types.abstract import VLMRunProtocol
+
+
+class Evaluations:
+    """Evaluations resource for VLM Run API."""
+
+    def __init__(self, client: "VLMRunProtocol") -> None:
+        """Initialize Evaluations resource with VLMRun instance.
+
+        Args:
+            client: VLM Run API instance
+        """
+        self._client = client
+        self._requestor = APIRequestor(client)
+
+    def list(
+        self,
+        limit: int = 30,
+        offset: int = 0,
+        order_by: str = "created_at",
+        descending: bool = True,
+        created_at_gte: Optional[str] = None,
+        created_at_lte: Optional[str] = None,
+    ) -> EvaluationRunListResponse:
+        """List evaluation runs with pagination and filtering.
+
+        Args:
+            limit: Maximum number of results to return (default: 30)
+            offset: Number of results to skip (default: 0)
+            order_by: Field to order by (default: "created_at")
+            descending: Sort in descending order (default: True)
+            created_at_gte: Filter runs created at or after this datetime (ISO format)
+            created_at_lte: Filter runs created at or before this datetime (ISO format)
+
+        Returns:
+            EvaluationRunListResponse: Paginated list of evaluation runs
+        """
+        params: Dict[str, Any] = {
+            "limit": limit,
+            "offset": offset,
+            "order_by": order_by,
+            "descending": descending,
+        }
+        if created_at_gte:
+            params["created_at__gte"] = created_at_gte
+        if created_at_lte:
+            params["created_at__lte"] = created_at_lte
+
+        response, status_code, headers = self._requestor.request(
+            method="GET", url="evaluations", params=params
+        )
+        return EvaluationRunListResponse(**response)
+
+    def get(self, run_id: str) -> EvaluationRunResponse:
+        """Get a specific evaluation run by ID.
+
+        Args:
+            run_id: The evaluation run ID
+
+        Returns:
+            EvaluationRunResponse: The evaluation run details
+        """
+        response, status_code, headers = self._requestor.request(
+            method="GET", url=f"evaluations/{run_id}"
+        )
+        return EvaluationRunResponse(**response)
+
+    def run(
+        self,
+        source_type: str,
+        source_id: str,
+        source_label: str,
+        execution_ids: Optional[List[str]] = None,
+        request_ids: Optional[List[str]] = None,
+        skill_ids: Optional[List[str]] = None,
+        data_from: Optional[str] = None,
+        data_to: Optional[str] = None,
+        evaluators: Optional[List[str]] = None,
+        infer_corrections: Optional[bool] = None,
+    ) -> EvaluationRunResponse:
+        """Trigger a new evaluation run.
+
+        Args:
+            source_type: Type of evaluation source ("agent", "request_domain", or "skill")
+            source_id: ID of the source to evaluate
+            source_label: Display label for the source
+            execution_ids: Optional list of execution IDs to evaluate
+            request_ids: Optional list of request IDs to evaluate
+            skill_ids: Optional list of skill IDs to evaluate
+            data_from: Optional start datetime for data range (ISO format)
+            data_to: Optional end datetime for data range (ISO format)
+            evaluators: Optional list of evaluator types to use
+            infer_corrections: Whether to infer corrections from feedback
+
+        Returns:
+            EvaluationRunResponse: The created evaluation run
+        """
+        data: Dict[str, Any] = {
+            "source_type": source_type,
+            "source_id": source_id,
+            "source_label": source_label,
+        }
+        if execution_ids is not None:
+            data["execution_ids"] = execution_ids
+        if request_ids is not None:
+            data["request_ids"] = request_ids
+        if skill_ids is not None:
+            data["skill_ids"] = skill_ids
+        if data_from is not None:
+            data["data_from"] = data_from
+        if data_to is not None:
+            data["data_to"] = data_to
+        if evaluators is not None:
+            data["evaluators"] = evaluators
+        if infer_corrections is not None:
+            data["infer_corrections"] = infer_corrections
+
+        response, status_code, headers = self._requestor.request(
+            method="POST", url="evaluations/run", data=data
+        )
+        return EvaluationRunResponse(**response)
+
+    def preview(
+        self,
+        source_type: str,
+        source_id: str,
+        data_from: Optional[str] = None,
+        data_to: Optional[str] = None,
+    ) -> EvaluationPreviewResponse:
+        """Get a preview of available data for an evaluation source.
+
+        Args:
+            source_type: Type of evaluation source
+            source_id: ID of the source
+            data_from: Optional start datetime for data range (ISO format)
+            data_to: Optional end datetime for data range (ISO format)
+
+        Returns:
+            EvaluationPreviewResponse: Preview of available evaluation data
+        """
+        params: Dict[str, str] = {
+            "source_type": source_type,
+            "source_id": source_id,
+        }
+        if data_from:
+            params["data_from"] = data_from
+        if data_to:
+            params["data_to"] = data_to
+
+        response, status_code, headers = self._requestor.request(
+            method="GET", url="evaluations/preview", params=params
+        )
+        return EvaluationPreviewResponse(**response)
+
+    def metrics(
+        self,
+        limit: int = 20,
+        source_type: Optional[str] = None,
+        source_label: Optional[str] = None,
+    ) -> EvaluationMetricsResponse:
+        """Get aggregated metrics across evaluation runs.
+
+        Args:
+            limit: Number of recent runs to aggregate over (default: 20)
+            source_type: Optional filter by source type
+            source_label: Optional filter by source label
+
+        Returns:
+            EvaluationMetricsResponse: Aggregated evaluation metrics
+        """
+        params: Dict[str, Any] = {"limit": limit}
+        if source_type:
+            params["source_type"] = source_type
+        if source_label:
+            params["source_label"] = source_label
+
+        response, status_code, headers = self._requestor.request(
+            method="GET", url="evaluations/metrics", params=params
+        )
+        return EvaluationMetricsResponse(**response)
+
+    def summary_stats(self) -> EvaluationSummaryStatsResponse:
+        """Get summary statistics for evaluation runs.
+
+        Returns:
+            EvaluationSummaryStatsResponse: Summary stats including total runs and source type counts
+        """
+        response, status_code, headers = self._requestor.request(
+            method="GET", url="evaluations/summary-stats"
+        )
+        return EvaluationSummaryStatsResponse(**response)
+
+    def unique_sources(self) -> EvaluationUniqueSourcesResponse:
+        """Get unique evaluation sources for filtering.
+
+        Returns:
+            EvaluationUniqueSourcesResponse: Unique (type, label) pairs
+        """
+        response, status_code, headers = self._requestor.request(
+            method="GET", url="evaluations/unique-sources"
+        )
+        return EvaluationUniqueSourcesResponse(**response)
+
+    def delete(self, run_id: str) -> None:
+        """Delete an evaluation run.
+
+        Args:
+            run_id: The evaluation run ID to delete
+        """
+        self._requestor.request(method="DELETE", url=f"evaluations/{run_id}")
+
+    def optimize_skill(
+        self,
+        skill_id: str,
+        skill_ids: Optional[List[str]] = None,
+        data_from: Optional[str] = None,
+        data_to: Optional[str] = None,
+        infer_corrections: bool = True,
+        n_samples: Optional[int] = None,
+    ) -> OptimizeSkillResponse:
+        """Optimize a skill based on evaluation data.
+
+        Args:
+            skill_id: The skill ID to optimize
+            skill_ids: Optional list of additional skill IDs
+            data_from: Optional start datetime for data range (ISO format)
+            data_to: Optional end datetime for data range (ISO format)
+            infer_corrections: Whether to infer corrections (default: True)
+            n_samples: Optional number of samples to use
+
+        Returns:
+            OptimizeSkillResponse: The optimization result
+        """
+        data: Dict[str, Any] = {"skill_id": skill_id}
+        if skill_ids is not None:
+            data["skill_ids"] = skill_ids
+        if data_from is not None:
+            data["data_from"] = data_from
+        if data_to is not None:
+            data["data_to"] = data_to
+        data["infer_corrections"] = infer_corrections
+        if n_samples is not None:
+            data["n_samples"] = n_samples
+
+        response, status_code, headers = self._requestor.request(
+            method="POST", url="evaluations/optimize", data=data
+        )
+        return OptimizeSkillResponse(**response)
+
+    def rerun_skill(
+        self,
+        evaluation_id: str,
+        skill_id: Optional[str] = None,
+        evaluators: Optional[List[str]] = None,
+        infer_corrections: bool = True,
+        n_samples: Optional[int] = None,
+    ) -> RerunSkillResponse:
+        """Re-run an evaluation with different parameters.
+
+        Args:
+            evaluation_id: The evaluation run ID to re-run
+            skill_id: Optional skill ID to use for the re-run
+            evaluators: Optional list of evaluator types to use
+            infer_corrections: Whether to infer corrections (default: True)
+            n_samples: Optional number of samples to use
+
+        Returns:
+            RerunSkillResponse: The re-run result
+        """
+        data: Dict[str, Any] = {"evaluation_id": evaluation_id}
+        if skill_id is not None:
+            data["skill_id"] = skill_id
+        if evaluators is not None:
+            data["evaluators"] = evaluators
+        data["infer_corrections"] = infer_corrections
+        if n_samples is not None:
+            data["n_samples"] = n_samples
+
+        response, status_code, headers = self._requestor.request(
+            method="POST", url="evaluations/rerun", data=data
+        )
+        return RerunSkillResponse(**response)

--- a/vlmrun/client/types.py
+++ b/vlmrun/client/types.py
@@ -573,6 +573,145 @@ class AgentSkill(BaseModel):
         )
 
 
+# --- Evaluation types ---
+
+EvaluationSourceType = Literal["agent", "request_domain", "skill"]
+EvaluatorType = Literal[
+    "field_accuracy", "fuzzy_field_match", "llm_judge", "equals_expected"
+]
+
+
+class EvaluationRunResponse(BaseModel):
+    """Response model for an evaluation run."""
+
+    id: str
+    source_type: str
+    source_id: Optional[str] = None
+    source_label: str
+    source_version: Optional[str] = None
+    status: str = "pending"
+    accuracy: Optional[float] = None
+    api_completion_rate: Optional[float] = None
+    total_items: Optional[int] = None
+    total_with_feedback: Optional[int] = None
+    data_from: Optional[str] = None
+    data_to: Optional[str] = None
+    results: Dict[str, Any] = {}
+    created_at: Optional[str] = None
+
+
+class EvaluationRunListResponse(BaseModel):
+    """Paginated list of evaluation runs."""
+
+    data: List[EvaluationRunResponse]
+    count: int
+
+
+class EvaluationPreviewResponse(BaseModel):
+    """Preview of available data for an evaluation source."""
+
+    total_items: int
+    total_with_feedback: int
+    feedback_with_corrections: int
+    latest_item_at: Optional[str] = None
+
+
+class AccuracyTrendPoint(BaseModel):
+    """A single point in the accuracy trend."""
+
+    run_id: str
+    accuracy: float
+    api_completion_rate: Optional[float] = None
+    fuzzy_match_rate: Optional[float] = None
+    exact_match_rate: Optional[float] = None
+    source_type: Optional[str] = None
+    source_label: Optional[str] = None
+    created_at: str
+
+
+class FieldAccuracyAggregate(BaseModel):
+    """Aggregated field accuracy metrics."""
+
+    field: str
+    avg_accuracy: float
+    total_correct: int
+    total_count: int
+
+
+class LatencyTrendPoint(BaseModel):
+    """A single point in the latency trend."""
+
+    run_id: str
+    created_at: str
+    p50_ms: Optional[float] = None
+    p90_ms: Optional[float] = None
+    p95_ms: Optional[float] = None
+
+
+class SourceTypeCount(BaseModel):
+    """Count of evaluation runs by source type."""
+
+    type: str
+    label: str
+    count: int
+
+
+class UniqueSource(BaseModel):
+    """A unique evaluation source."""
+
+    type: str
+    label: str
+
+
+class EvaluationMetricsResponse(BaseModel):
+    """Aggregated evaluation metrics."""
+
+    accuracy_trend: List[AccuracyTrendPoint]
+    avg_accuracy: Optional[float] = None
+    accuracy_delta: Optional[float] = None
+    avg_api_completion_rate: Optional[float] = None
+    avg_fuzzy_match_rate: Optional[float] = None
+    avg_exact_match_rate: Optional[float] = None
+    field_accuracies: List[FieldAccuracyAggregate]
+    latency_trend: List[LatencyTrendPoint]
+    p50_ms: Optional[float] = None
+    p90_ms: Optional[float] = None
+    p95_ms: Optional[float] = None
+
+
+class EvaluationSummaryStatsResponse(BaseModel):
+    """Summary statistics for evaluation runs."""
+
+    total_runs: int
+    source_type_counts: List[SourceTypeCount]
+
+
+class EvaluationUniqueSourcesResponse(BaseModel):
+    """Unique evaluation sources for filtering."""
+
+    sources: List[UniqueSource]
+
+
+class OptimizeSkillResponse(BaseModel):
+    """Response from skill optimization."""
+
+    skill_id: str
+    name: str
+    version: str
+    original_skill_id: str
+    total_pairs: int
+    sampled_pairs: int
+    created_at: str
+
+
+class RerunSkillResponse(BaseModel):
+    """Response from evaluation re-run."""
+
+    evaluation_id: str
+    skill_id: str
+    status: str
+
+
 class GenerationConfig(BaseModel):
     prompt: Optional[str] = Field(default=None)
     response_model: Optional[Type[BaseModel]] = Field(default=None)

--- a/vlmrun/client/types.py
+++ b/vlmrun/client/types.py
@@ -586,24 +586,24 @@ class EvaluationRunResponse(BaseModel):
 
     id: str
     source_type: str
-    source_id: str | None = None
+    source_id: Optional[str] = None
     source_label: str
-    source_version: str | None = None
+    source_version: Optional[str] = None
     status: str = "pending"
-    accuracy: float | None = None
-    api_completion_rate: float | None = None
-    total_items: int | None = None
-    total_with_feedback: int | None = None
-    data_from: str | None = None
-    data_to: str | None = None
-    results: dict[str, Any] = {}
-    created_at: str | None = None
+    accuracy: Optional[float] = None
+    api_completion_rate: Optional[float] = None
+    total_items: Optional[int] = None
+    total_with_feedback: Optional[int] = None
+    data_from: Optional[str] = None
+    data_to: Optional[str] = None
+    results: Dict[str, Any] = {}
+    created_at: Optional[str] = None
 
 
 class EvaluationRunListResponse(BaseModel):
     """Paginated list of evaluation runs."""
 
-    data: list[EvaluationRunResponse]
+    data: List[EvaluationRunResponse]
     count: int
 
 
@@ -613,7 +613,7 @@ class EvaluationPreviewResponse(BaseModel):
     total_items: int
     total_with_feedback: int
     feedback_with_corrections: int
-    latest_item_at: str | None = None
+    latest_item_at: Optional[str] = None
 
 
 class AccuracyTrendPoint(BaseModel):
@@ -621,11 +621,11 @@ class AccuracyTrendPoint(BaseModel):
 
     run_id: str
     accuracy: float
-    api_completion_rate: float | None = None
-    fuzzy_match_rate: float | None = None
-    exact_match_rate: float | None = None
-    source_type: str | None = None
-    source_label: str | None = None
+    api_completion_rate: Optional[float] = None
+    fuzzy_match_rate: Optional[float] = None
+    exact_match_rate: Optional[float] = None
+    source_type: Optional[str] = None
+    source_label: Optional[str] = None
     created_at: str
 
 
@@ -643,9 +643,9 @@ class LatencyTrendPoint(BaseModel):
 
     run_id: str
     created_at: str
-    p50_ms: float | None = None
-    p90_ms: float | None = None
-    p95_ms: float | None = None
+    p50_ms: Optional[float] = None
+    p90_ms: Optional[float] = None
+    p95_ms: Optional[float] = None
 
 
 class SourceTypeCount(BaseModel):
@@ -666,30 +666,30 @@ class UniqueSource(BaseModel):
 class EvaluationMetricsResponse(BaseModel):
     """Aggregated evaluation metrics."""
 
-    accuracy_trend: list[AccuracyTrendPoint]
-    avg_accuracy: float | None = None
-    accuracy_delta: float | None = None
-    avg_api_completion_rate: float | None = None
-    avg_fuzzy_match_rate: float | None = None
-    avg_exact_match_rate: float | None = None
-    field_accuracies: list[FieldAccuracyAggregate]
-    latency_trend: list[LatencyTrendPoint]
-    p50_ms: float | None = None
-    p90_ms: float | None = None
-    p95_ms: float | None = None
+    accuracy_trend: List[AccuracyTrendPoint]
+    avg_accuracy: Optional[float] = None
+    accuracy_delta: Optional[float] = None
+    avg_api_completion_rate: Optional[float] = None
+    avg_fuzzy_match_rate: Optional[float] = None
+    avg_exact_match_rate: Optional[float] = None
+    field_accuracies: List[FieldAccuracyAggregate]
+    latency_trend: List[LatencyTrendPoint]
+    p50_ms: Optional[float] = None
+    p90_ms: Optional[float] = None
+    p95_ms: Optional[float] = None
 
 
 class EvaluationSummaryStatsResponse(BaseModel):
     """Summary statistics for evaluation runs."""
 
     total_runs: int
-    source_type_counts: list[SourceTypeCount]
+    source_type_counts: List[SourceTypeCount]
 
 
 class EvaluationUniqueSourcesResponse(BaseModel):
     """Unique evaluation sources for filtering."""
 
-    sources: list[UniqueSource]
+    sources: List[UniqueSource]
 
 
 class GenerationConfig(BaseModel):

--- a/vlmrun/client/types.py
+++ b/vlmrun/client/types.py
@@ -692,26 +692,6 @@ class EvaluationUniqueSourcesResponse(BaseModel):
     sources: list[UniqueSource]
 
 
-class OptimizeSkillResponse(BaseModel):
-    """Response from skill optimization."""
-
-    skill_id: str
-    name: str
-    version: str
-    original_skill_id: str
-    total_pairs: int
-    sampled_pairs: int
-    created_at: str
-
-
-class RerunSkillResponse(BaseModel):
-    """Response from evaluation re-run."""
-
-    evaluation_id: str
-    skill_id: str
-    status: str
-
-
 class GenerationConfig(BaseModel):
     prompt: Optional[str] = Field(default=None)
     response_model: Optional[Type[BaseModel]] = Field(default=None)

--- a/vlmrun/client/types.py
+++ b/vlmrun/client/types.py
@@ -586,24 +586,24 @@ class EvaluationRunResponse(BaseModel):
 
     id: str
     source_type: str
-    source_id: Optional[str] = None
+    source_id: str | None = None
     source_label: str
-    source_version: Optional[str] = None
+    source_version: str | None = None
     status: str = "pending"
-    accuracy: Optional[float] = None
-    api_completion_rate: Optional[float] = None
-    total_items: Optional[int] = None
-    total_with_feedback: Optional[int] = None
-    data_from: Optional[str] = None
-    data_to: Optional[str] = None
-    results: Dict[str, Any] = {}
-    created_at: Optional[str] = None
+    accuracy: float | None = None
+    api_completion_rate: float | None = None
+    total_items: int | None = None
+    total_with_feedback: int | None = None
+    data_from: str | None = None
+    data_to: str | None = None
+    results: dict[str, Any] = {}
+    created_at: str | None = None
 
 
 class EvaluationRunListResponse(BaseModel):
     """Paginated list of evaluation runs."""
 
-    data: List[EvaluationRunResponse]
+    data: list[EvaluationRunResponse]
     count: int
 
 
@@ -613,7 +613,7 @@ class EvaluationPreviewResponse(BaseModel):
     total_items: int
     total_with_feedback: int
     feedback_with_corrections: int
-    latest_item_at: Optional[str] = None
+    latest_item_at: str | None = None
 
 
 class AccuracyTrendPoint(BaseModel):
@@ -621,11 +621,11 @@ class AccuracyTrendPoint(BaseModel):
 
     run_id: str
     accuracy: float
-    api_completion_rate: Optional[float] = None
-    fuzzy_match_rate: Optional[float] = None
-    exact_match_rate: Optional[float] = None
-    source_type: Optional[str] = None
-    source_label: Optional[str] = None
+    api_completion_rate: float | None = None
+    fuzzy_match_rate: float | None = None
+    exact_match_rate: float | None = None
+    source_type: str | None = None
+    source_label: str | None = None
     created_at: str
 
 
@@ -643,9 +643,9 @@ class LatencyTrendPoint(BaseModel):
 
     run_id: str
     created_at: str
-    p50_ms: Optional[float] = None
-    p90_ms: Optional[float] = None
-    p95_ms: Optional[float] = None
+    p50_ms: float | None = None
+    p90_ms: float | None = None
+    p95_ms: float | None = None
 
 
 class SourceTypeCount(BaseModel):
@@ -666,30 +666,30 @@ class UniqueSource(BaseModel):
 class EvaluationMetricsResponse(BaseModel):
     """Aggregated evaluation metrics."""
 
-    accuracy_trend: List[AccuracyTrendPoint]
-    avg_accuracy: Optional[float] = None
-    accuracy_delta: Optional[float] = None
-    avg_api_completion_rate: Optional[float] = None
-    avg_fuzzy_match_rate: Optional[float] = None
-    avg_exact_match_rate: Optional[float] = None
-    field_accuracies: List[FieldAccuracyAggregate]
-    latency_trend: List[LatencyTrendPoint]
-    p50_ms: Optional[float] = None
-    p90_ms: Optional[float] = None
-    p95_ms: Optional[float] = None
+    accuracy_trend: list[AccuracyTrendPoint]
+    avg_accuracy: float | None = None
+    accuracy_delta: float | None = None
+    avg_api_completion_rate: float | None = None
+    avg_fuzzy_match_rate: float | None = None
+    avg_exact_match_rate: float | None = None
+    field_accuracies: list[FieldAccuracyAggregate]
+    latency_trend: list[LatencyTrendPoint]
+    p50_ms: float | None = None
+    p90_ms: float | None = None
+    p95_ms: float | None = None
 
 
 class EvaluationSummaryStatsResponse(BaseModel):
     """Summary statistics for evaluation runs."""
 
     total_runs: int
-    source_type_counts: List[SourceTypeCount]
+    source_type_counts: list[SourceTypeCount]
 
 
 class EvaluationUniqueSourcesResponse(BaseModel):
     """Unique evaluation sources for filtering."""
 
-    sources: List[UniqueSource]
+    sources: list[UniqueSource]
 
 
 class OptimizeSkillResponse(BaseModel):


### PR DESCRIPTION
## Summary

Adds a new `Evaluations` resource to the Python SDK, exposing read-only evaluation API endpoints. Changes across 5 files:

- **`vlmrun/client/evaluations.py`** (new): `Evaluations` class with 7 methods — `list`, `get`, `preview`, `metrics`, `summary_stats`, `unique_sources`, `delete`
- **`vlmrun/client/types.py`**: 9 new Pydantic models for evaluation response types (`EvaluationRunResponse`, `EvaluationMetricsResponse`, `AccuracyTrendPoint`, etc.) plus `EvaluationSourceType` and `EvaluatorType` Literal aliases
- **`vlmrun/client/client.py`**: Wires `Evaluations` into the `VLMRun` client as `self.evaluations`
- **`tests/test_evaluations.py`** (new): 7 unit tests covering all public methods
- **`tests/conftest.py`**: `Evaluations` mock class added to `MockVLMRun`

Follows existing resource patterns (Feedback, Artifacts, etc.) using `APIRequestor` for HTTP calls. Pydantic model fields use `Optional[X]` / `List[T]` / `Dict[K, V]` from `typing` for Python 3.9 compatibility.

### Updates since last revision

- **Removed write operations** (`run`, `optimize_skill`, `rerun_skill`) and their associated request/response types per reviewer feedback — only endpoints available in the vlm-lab backend are included.
- **Fixed Python 3.9 compatibility**: Pydantic model field annotations now use `Optional[X]`, `List[T]`, `Dict[K, V]` from `typing` instead of `str | None` / `list[T]` / `dict[K, V]` syntax (Pydantic evaluates field annotations at runtime, so `from __future__ import annotations` does not help).

## Review & Testing Checklist for Human

- [ ] **Validate type definitions against actual backend API schema.** All Pydantic models were inferred from vlm-cloud frontend usage, not the backend OpenAPI spec. Field names, types, and optionality (e.g., `results: Dict[str, Any]`, nullable fields) may not match the real API contract. Deserializing a live response is the only way to confirm.
- [ ] **Verify query parameter naming conventions.** `list()` sends `created_at__gte` / `created_at__lte` (Django double-underscore style). Confirm the backend expects this exact format.
- [ ] **`EvaluationSourceType` and `EvaluatorType` Literals are defined but unused in method signatures** — `preview()` and `metrics()` accept plain `str` for `source_type`. Consider whether these should use the Literal types for compile-time safety, or be removed.
- [ ] **Tests are mock-based only.** 7 unit tests exercise mock responses, not real API serialization. Recommend a manual smoke test against a live endpoint.

**Suggested manual test plan:** Instantiate `VLMRun` with a valid API key, call `client.evaluations.list()` and `client.evaluations.summary_stats()`, and confirm the responses deserialize without `ValidationError`.

### Notes
- `list()` defaults: `limit=30`, `offset=0`, `order_by="created_at"`, `descending=True`. Verify these are appropriate for the backend.
- A corresponding Node SDK PR is available at https://github.com/vlm-run/vlmrun-node-sdk/pull/129.

Link to Devin session: https://app.devin.ai/sessions/e8157dfb67844254bf3d6c358c57ebe5
Requested by: @Mirajul-Mohin
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-python-sdk/pull/183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
