### PR TITLE
feat(pricing): add `service_tier` to `GenerationConfig`

### DIFF
--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -573,3 +573,30 @@ def test_document_markdown_automatic_casting_in_get(mock_client, monkeypatch):
     assert isinstance(response, PredictionResponse)
     assert not isinstance(response.response, MarkdownDocument)
     assert isinstance(response.response, dict)
+
+
+@pytest.mark.parametrize(
+    "service_tier", ["auto", "default", "standard", "flex", "priority"]
+)
+def test_generation_config_service_tier(service_tier):
+    """service_tier is accepted and round-trips through model_dump()."""
+    config = GenerationConfig(service_tier=service_tier)
+    assert config.service_tier == service_tier
+    dumped = config.model_dump()
+    assert dumped["service_tier"] == service_tier
+
+
+def test_generation_config_service_tier_default_is_none():
+    """service_tier defaults to None and is excluded from model_dump()."""
+    config = GenerationConfig()
+    assert config.service_tier is None
+    dumped = config.model_dump()
+    assert "service_tier" not in dumped
+
+
+def test_generation_config_service_tier_invalid():
+    """Invalid service_tier values are rejected by pydantic."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        GenerationConfig(service_tier="ultra")

--- a/vlmrun/client/types.py
+++ b/vlmrun/client/types.py
@@ -597,6 +597,19 @@ class GenerationConfig(BaseModel):
         default=None,
         description="0-indexed page indices to process for document files. If None, all pages are processed.",
     )
+    service_tier: Optional[
+        Literal["auto", "default", "standard", "flex", "priority"]
+    ] = Field(
+        default=None,
+        description=(
+            "Delivery tier mirroring OpenAI's service_tier and Vertex AI's "
+            "Gemini Flex/Priority offering. 'standard'/'default' uses baseline "
+            "rates, 'flex' applies a 50% discount with higher latency, "
+            "'priority' applies a 1.8x premium. When omitted (or 'auto'), the "
+            "server default applies (which itself defaults to 'standard'). The "
+            "chosen tier drives BOTH billing AND the actual request routing."
+        ),
+    )
     skills: Optional[List["AgentSkill"]] = Field(
         default=None,
         description="List of agent skills to enable for this request. Skills provide domain-specific expertise and capabilities.",

--- a/vlmrun/client/types.py
+++ b/vlmrun/client/types.py
@@ -597,9 +597,7 @@ class GenerationConfig(BaseModel):
         default=None,
         description="0-indexed page indices to process for document files. If None, all pages are processed.",
     )
-    service_tier: Optional[
-        Literal["auto", "default", "standard", "flex", "priority"]
-    ] = Field(
+    service_tier: Literal["auto", "default", "standard", "flex", "priority"] | None = Field(
         default=None,
         description=(
             "Delivery tier mirroring OpenAI's service_tier and Vertex AI's "


### PR DESCRIPTION
## Summary

Mirrors [vlm-run/vlm-lab#1826](https://github.com/vlm-run/vlm-lab/pull/1826) in the Python SDK.

Adds a new optional `service_tier` field to `GenerationConfig` so callers can opt into Flex/Priority pricing on any `image|document|video|audio.generate(..)` / `.execute(..)` request. The server propagates the tier via a contextvar into both the Vertex AI HTTP header (so Gemini routes the call to the correct tier) and the billing calculator.

**Tiers:**
- `standard` / `default` — 1.0× rate (server default)
- `flex` — 0.5× rate (50% discount, higher latency)
- `priority` — 1.8× rate (higher premium, highest reliability)
- `auto` / `None` — falls back to the server-side default (currently `standard`)

### Changes
- `vlmrun/client/types.py`: added `service_tier: Literal["auto", "default", "standard", "flex", "priority"] | None = None` on `GenerationConfig`. Default `None` is omitted from the wire payload (matches existing `exclude_none=True` semantics).
- `tests/test_predictions.py`: added unit tests covering accepted values, default-None behaviour, `model_dump()` round-trip, and pydantic validation of invalid values.

### Usage

```python
from vlmrun.client.types import GenerationConfig

# 50% off (flex)
response = client.document.generate(
    url="https://example.com/invoice.pdf",
    domain="document.invoice",
    config=GenerationConfig(service_tier="flex"),
)

# Highest reliability (priority)
response = client.image.generate(
    images=[image],
    domain="document.invoice",
    config=GenerationConfig(service_tier="priority"),
)
```

## Review & Testing Checklist for Human

- [ ] Confirm the `service_tier` literal values match the server-side contract in [vlm-run/vlm-lab#1826](https://github.com/vlm-run/vlm-lab/pull/1826) (`auto`, `default`, `standard`, `flex`, `priority`).
- [ ] End-to-end smoke test: issue a `document.generate(..., config=GenerationConfig(service_tier="flex"))` against a `flex`-enabled deployment and verify the returned `usage.credits_used` is ~50% of the `standard` baseline.
- [ ] Confirm that omitting `service_tier` (default `None`) does not change existing request payloads (backwards compatible).

### Notes
- No client-side validation of the tier beyond the pydantic `Literal` — server remains the source of truth for which tiers are actually enabled for a given account.
- The `GenerationConfig.model_dump()` already passes `exclude_none=True`, so requests that don't set `service_tier` are unchanged on the wire.

Link to Devin session: https://app.devin.ai/sessions/0a5a9297f1214c94ab6c9fb253bfd560
Requested by: @dineshreddy91
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-python-sdk/pull/186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
