### PR TITLE
feat(cli): hide public skills from `vlmrun skills list` by default

### DIFF
--- a/tests/cli/test_cli_skills.py
+++ b/tests/cli/test_cli_skills.py
@@ -70,6 +70,40 @@ def test_list_skills_grouped(runner, mock_client, config_file):
     assert result.exit_code == 0
 
 
+def test_list_skills_default_excludes_public(
+    runner, mock_client, config_file, monkeypatch
+):
+    """skills list (no flag) requests only non-public skills (include_public=False)."""
+    captured = {}
+
+    def fake_list(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(mock_client.skills, "list", fake_list)
+    monkeypatch.setattr("vlmrun.cli.cli.VLMRun", lambda **kw: mock_client)
+    result = runner.invoke(app, ["skills", "list"])
+    assert result.exit_code == 0
+    assert captured.get("include_public") is False
+
+
+def test_list_skills_public_flag_includes_public(
+    runner, mock_client, config_file, monkeypatch
+):
+    """skills list --public requests public skills too (include_public=True)."""
+    captured = {}
+
+    def fake_list(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(mock_client.skills, "list", fake_list)
+    monkeypatch.setattr("vlmrun.cli.cli.VLMRun", lambda **kw: mock_client)
+    result = runner.invoke(app, ["skills", "list", "--public"])
+    assert result.exit_code == 0
+    assert captured.get("include_public") is True
+
+
 # ---------------------------------------------------------------------------
 # skills get
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,8 @@ def mock_client(monkeypatch):
                 order_by="created_at",
                 descending=True,
                 grouped=False,
+                include_public=True,
+                only_public=False,
             ):
                 return [
                     SkillInfo(

--- a/vlmrun/cli/README.md
+++ b/vlmrun/cli/README.md
@@ -246,8 +246,9 @@ vlmrun hub schema document.invoice
 Manage reusable skills (SKILL.md bundles) for specialized agent behavior.
 
 ```bash
-# List skills
+# List skills (only non-public skills owned by your organization by default)
 vlmrun skills list
+vlmrun skills list --public     # also include public skills
 vlmrun skills list --grouped    # latest version per name
 
 # Get a skill by name or ID

--- a/vlmrun/cli/_cli/skills.py
+++ b/vlmrun/cli/_cli/skills.py
@@ -62,8 +62,8 @@ def list_skills(
 ) -> None:
     """List available skills.
 
-    By default only non-public skills owned by your organization are shown.
-    Pass ``--public`` to include public skills as well.
+    By default, only non-public skills owned by your organization are shown.
+    Pass --public to include public skills as well.
     """
     client: VLMRun = ctx.obj
     skills = client.skills.list(

--- a/vlmrun/cli/_cli/skills.py
+++ b/vlmrun/cli/_cli/skills.py
@@ -52,9 +52,19 @@ def list_skills(
         "-g",
         help="Show only the latest version of each skill name.",
     ),
+    public: bool = typer.Option(
+        False,
+        "--public",
+        help="Include public skills in the listing. By default, only the caller's "
+        "non-public (organization-owned) skills are shown.",
+    ),
     output_json: bool = typer.Option(False, "--json", "-j", help="Output raw JSON."),
 ) -> None:
-    """List available skills."""
+    """List available skills.
+
+    By default only non-public skills owned by your organization are shown.
+    Pass ``--public`` to include public skills as well.
+    """
     client: VLMRun = ctx.obj
     skills = client.skills.list(
         limit=limit,
@@ -62,6 +72,7 @@ def list_skills(
         order_by=order_by,
         descending=descending,
         grouped=grouped,
+        include_public=public,
     )
 
     if not skills:

--- a/vlmrun/client/skills.py
+++ b/vlmrun/client/skills.py
@@ -98,6 +98,8 @@ class Skills:
         order_by: str = "created_at",
         descending: bool = True,
         grouped: bool = False,
+        include_public: bool = True,
+        only_public: bool = False,
     ) -> List[SkillInfo]:
         """List available skills.
 
@@ -107,6 +109,10 @@ class Skills:
             order_by: Sort field (created_at, updated_at, name).
             descending: Sort direction.
             grouped: If True, return only the latest version per skill name.
+            include_public: If True, include public skills alongside the
+                caller's organization skills. Defaults to True to preserve
+                the server's existing behavior.
+            only_public: If True, return only public skills.
 
         Returns:
             List of SkillInfo objects
@@ -117,6 +123,8 @@ class Skills:
             "order_by": order_by,
             "descending": descending,
             "grouped": grouped,
+            "include_public": include_public,
+            "only_public": only_public,
         }
         response, status_code, headers = self._requestor.request(
             method="GET",


### PR DESCRIPTION
## Summary

`vlmrun skills list` now shows only **non-public** (organization-owned) skills by default. Pass `--public` to include public skills in the listing alongside your private ones.

Changes:
- `vlmrun/cli/_cli/skills.py` — added a `--public` flag to `vlmrun skills list`. When omitted, the CLI passes `include_public=False` to the API so only the caller's non-public skills are returned. When `--public` is set, it passes `include_public=True` and all accessible (public + private) skills are returned.
- `vlmrun/client/skills.py` — plumbed `include_public` and `only_public` parameters through `Skills.list()` so SDK consumers can request the same filtering. Defaults preserve existing server behavior for direct SDK callers (`include_public=True`, `only_public=False`).
- `vlmrun/cli/README.md` — documented the new `--public` flag.
- `tests/cli/test_cli_skills.py` — added two tests verifying the CLI passes `include_public=False` by default and `include_public=True` when `--public` is provided.
- `tests/conftest.py` — extended the `MockVLMRun.Skills.list` signature to accept the new kwargs.

This maps to the existing `include_public` query parameter on `GET /v1/skills` (defined in `vlm-cloud/backend/app/api/routes/skills.py`), so no server-side change is needed.

## Review & Testing Checklist for Human

- [ ] Run `vlmrun skills list` against a real account and confirm the table now shows only non-public (organization-owned) skills.
- [ ] Run `vlmrun skills list --public` and confirm public skills are included again.
- [ ] Confirm that scripts/integrations using `client.skills.list()` directly (without arguments) keep their current behavior (the SDK default still includes public skills, only the CLI default changes).

### Notes

- The SDK method default (`include_public=True`) is intentionally kept as-is to avoid breaking existing programmatic consumers; only the CLI default behavior is flipped, as requested.
- `only_public` is also exposed on `Skills.list()` for completeness but isn't surfaced as a CLI flag — happy to add it (e.g. `--only-public`) if useful.

Link to Devin session: https://app.devin.ai/sessions/c34b623c3551437dab8a45b3d272029f
Requested by: @spillai
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-python-sdk/pull/190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->