### PR TITLE
fix: increase agent execute and chat completions timeouts to ≥600s

### DIFF
--- a/vlmrun/client/agent.py
+++ b/vlmrun/client/agent.py
@@ -320,7 +320,7 @@ class Agent:
         openai_client = OpenAI(
             api_key=self._client.api_key,
             base_url=base_url,
-            timeout=self._client.timeout,
+            timeout=max(self._client.timeout, 600),
             max_retries=self._client.max_retries,
         )
 
@@ -374,7 +374,7 @@ class Agent:
         async_openai_client = AsyncOpenAI(
             api_key=self._client.api_key,
             base_url=base_url,
-            timeout=self._client.timeout,
+            timeout=max(self._client.timeout, 600),
             max_retries=self._client.max_retries,
         )
 

--- a/vlmrun/client/agent.py
+++ b/vlmrun/client/agent.py
@@ -320,7 +320,7 @@ class Agent:
         openai_client = OpenAI(
             api_key=self._client.api_key,
             base_url=base_url,
-            timeout=max(self._client.timeout, 600),
+            timeout=self._client.timeout if self._client.timeout is None else max(self._client.timeout, 600),
             max_retries=self._client.max_retries,
         )
 
@@ -374,7 +374,7 @@ class Agent:
         async_openai_client = AsyncOpenAI(
             api_key=self._client.api_key,
             base_url=base_url,
-            timeout=max(self._client.timeout, 600),
+            timeout=self._client.timeout if self._client.timeout is None else max(self._client.timeout, 600),
             max_retries=self._client.max_retries,
         )
 

--- a/vlmrun/client/executions.py
+++ b/vlmrun/client/executions.py
@@ -20,7 +20,7 @@ class Executions:
             client: VLM Run API instance
         """
         self._client = client
-        self._requestor = APIRequestor(client, timeout=600)
+        self._requestor = APIRequestor(client, timeout=120)
 
     def list(self, skip: int = 0, limit: int = 10) -> list[AgentExecutionResponse]:
         """List all executions.

--- a/vlmrun/client/executions.py
+++ b/vlmrun/client/executions.py
@@ -20,7 +20,7 @@ class Executions:
             client: VLM Run API instance
         """
         self._client = client
-        self._requestor = APIRequestor(client, timeout=120)
+        self._requestor = APIRequestor(client, timeout=600)
 
     def list(self, skip: int = 0, limit: int = 10) -> list[AgentExecutionResponse]:
         """List all executions.
@@ -57,7 +57,7 @@ class Executions:
         return AgentExecutionResponse(**response)
 
     def wait(
-        self, id: str, timeout: int = 300, sleep: int = 5
+        self, id: str, timeout: int = 600, sleep: int = 5
     ) -> AgentExecutionResponse:
         """Wait for execution to complete.
 

--- a/vlmrun/client/predictions.py
+++ b/vlmrun/client/predictions.py
@@ -129,7 +129,7 @@ class Predictions:
 
         return prediction
 
-    def wait(self, id: str, timeout: int = 300, sleep: int = 5) -> PredictionResponse:
+    def wait(self, id: str, timeout: int = 600, sleep: int = 5) -> PredictionResponse:
         """Wait for prediction to complete.
 
         Args:


### PR DESCRIPTION
## Summary

Increase timeouts for Orion agent execute and chat completions to ≥600s to prevent premature errors and retries on long-running tasks.

**Changes:**

| Location | Before | After |
|---|---|---|
| `Agent.completions` / `Agent.async_completions` OpenAI client | `self._client.timeout` (120s default) | `max(self._client.timeout, 600)` |
| `Executions.__init__` APIRequestor | 120s | 600s |
| `Executions.wait()` default | 300s | 600s |
| `Predictions.wait()` default | 300s | 600s |

The `Agent.completions` change uses `max()` so users who explicitly set a timeout >600s keep their value, while the default 120s gets bumped to 600s.

Related PRs: vlm-run/vlmrun-node-sdk (same changes), vlm-run/vlm-lab (server-side timeouts).

Link to Devin session: https://app.devin.ai/sessions/977e2c561b8c4ef8b72d04517946a4dc
Requested by: @dineshreddy91
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-python-sdk/pull/194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->