### PR TITLE
feat: implement artifacts.list() and add filename param to artifacts.get()

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,8 @@ from pydantic import BaseModel
 from typer.testing import CliRunner
 
 from vlmrun.client.types import (
+    ArtifactListItem,
+    ArtifactListResponse,
     CreditUsage,
     DatasetResponse,
     FileResponse,
@@ -749,9 +751,10 @@ def mock_client(monkeypatch):
 
             def get(
                 self,
-                object_id: str,
+                object_id: str = None,
                 session_id: str = None,
                 execution_id: str = None,
+                filename: str = None,
                 raw_response: bool = False,
             ) -> bytes:
                 if session_id is None and execution_id is None:
@@ -762,10 +765,43 @@ def mock_client(monkeypatch):
                     raise ValueError(
                         "Only one of `session_id` or `execution_id` is allowed, not both"
                     )
+                if object_id is None and filename is None:
+                    raise ValueError("Either `object_id` or `filename` is required")
+                if object_id is not None and filename is not None:
+                    raise ValueError(
+                        "Only one of `object_id` or `filename` is allowed, not both"
+                    )
                 return b"mock artifact content"
 
-            def list(self, session_id: str):
-                raise NotImplementedError("Artifacts.list() is not yet implemented")
+            def list(
+                self,
+                session_id: str = None,
+                execution_id: str = None,
+            ) -> ArtifactListResponse:
+                if session_id is None and execution_id is None:
+                    raise ValueError(
+                        "Either `session_id` or `execution_id` is required"
+                    )
+                if session_id is not None and execution_id is not None:
+                    raise ValueError(
+                        "Only one of `session_id` or `execution_id` is allowed, not both"
+                    )
+                namespace_id = session_id or execution_id
+                return ArtifactListResponse(
+                    namespace_id=namespace_id,
+                    items=[
+                        ArtifactListItem(
+                            object_id="img_a1b2c3",
+                            filename="screenshot.png",
+                            source="store",
+                        ),
+                        ArtifactListItem(
+                            object_id="doc_d4e5f6",
+                            filename=None,
+                            source="manifest",
+                        ),
+                    ],
+                )
 
     monkeypatch.setattr("vlmrun.cli.cli.VLMRun", MockVLMRun)
     return MockVLMRun()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from vlmrun.client.types import ArtifactListResponse
+
 
 def test_get_artifact(mock_client):
     """Test getting an artifact by session_id and object_id."""
@@ -13,8 +15,71 @@ def test_get_artifact(mock_client):
     assert response == b"mock artifact content"
 
 
-def test_list_artifacts_not_implemented(mock_client):
-    """Test that list() raises NotImplementedError."""
-    with pytest.raises(NotImplementedError) as exc_info:
-        mock_client.artifacts.list(session_id="550e8400-e29b-41d4-a716-446655440000")
-    assert "not yet implemented" in str(exc_info.value)
+def test_get_artifact_by_filename(mock_client):
+    """Test getting an artifact by filename."""
+    response = mock_client.artifacts.get(
+        filename="screenshot.png",
+        session_id="550e8400-e29b-41d4-a716-446655440000",
+    )
+    assert isinstance(response, bytes)
+    assert response == b"mock artifact content"
+
+
+def test_get_artifact_requires_object_id_or_filename(mock_client):
+    """Test that get() raises ValueError when neither object_id nor filename is provided."""
+    with pytest.raises(
+        ValueError, match="Either `object_id` or `filename` is required"
+    ):
+        mock_client.artifacts.get(
+            session_id="550e8400-e29b-41d4-a716-446655440000",
+        )
+
+
+def test_get_artifact_rejects_both_object_id_and_filename(mock_client):
+    """Test that get() raises ValueError when both object_id and filename are provided."""
+    with pytest.raises(ValueError, match="Only one of `object_id` or `filename`"):
+        mock_client.artifacts.get(
+            object_id="img_a1b2c3",
+            filename="screenshot.png",
+            session_id="550e8400-e29b-41d4-a716-446655440000",
+        )
+
+
+def test_list_artifacts_by_session_id(mock_client):
+    """Test listing artifacts by session_id."""
+    session_id = "550e8400-e29b-41d4-a716-446655440000"
+    result = mock_client.artifacts.list(session_id=session_id)
+    assert isinstance(result, ArtifactListResponse)
+    assert result.namespace_id == session_id
+    assert len(result.items) == 2
+    assert result.items[0].object_id == "img_a1b2c3"
+    assert result.items[0].filename == "screenshot.png"
+    assert result.items[0].source == "store"
+    assert result.items[1].object_id == "doc_d4e5f6"
+    assert result.items[1].filename is None
+    assert result.items[1].source == "manifest"
+
+
+def test_list_artifacts_by_execution_id(mock_client):
+    """Test listing artifacts by execution_id."""
+    execution_id = "exec-12345"
+    result = mock_client.artifacts.list(execution_id=execution_id)
+    assert isinstance(result, ArtifactListResponse)
+    assert result.namespace_id == execution_id
+
+
+def test_list_artifacts_requires_namespace(mock_client):
+    """Test that list() raises ValueError when no namespace is provided."""
+    with pytest.raises(
+        ValueError, match="Either `session_id` or `execution_id` is required"
+    ):
+        mock_client.artifacts.list()
+
+
+def test_list_artifacts_rejects_both_ids(mock_client):
+    """Test that list() raises ValueError when both session_id and execution_id are provided."""
+    with pytest.raises(ValueError, match="Only one of `session_id` or `execution_id`"):
+        mock_client.artifacts.list(
+            session_id="sess-123",
+            execution_id="exec-456",
+        )

--- a/vlmrun/cli/_cli/artifacts.py
+++ b/vlmrun/cli/_cli/artifacts.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import typer
 from rich.console import Console
 from rich.panel import Panel
+from rich.table import Table
 from rich.text import Text
 
 if TYPE_CHECKING:
@@ -20,6 +21,57 @@ app = typer.Typer(
 )
 
 console = Console()
+
+
+@app.command()
+def list(
+    ctx: typer.Context,
+    session_id: str | None = typer.Option(
+        None,
+        "--session-id",
+        "-s",
+        help="Session ID to list artifacts for (mutually exclusive with --execution-id)",
+    ),
+    execution_id: str | None = typer.Option(
+        None,
+        "--execution-id",
+        "-e",
+        help="Execution ID to list artifacts for (mutually exclusive with --session-id)",
+    ),
+) -> None:
+    """List artifacts for a session or execution."""
+    client: VLMRun = ctx.obj
+
+    if session_id is None and execution_id is None:
+        console.print(
+            "[red bold]Error:[/] Either --session-id or --execution-id is required."
+        )
+        raise typer.Exit(1)
+
+    if session_id is not None and execution_id is not None:
+        console.print(
+            "[red bold]Error:[/] Only one of --session-id or --execution-id is allowed, not both."
+        )
+        raise typer.Exit(1)
+
+    try:
+        result = client.artifacts.list(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+    except Exception as exc:
+        console.print(f"[red bold]Error:[/] {exc}")
+        raise typer.Exit(1) from exc
+
+    table = Table(title=f"Artifacts ({result.namespace_id})")
+    table.add_column("Object ID", style="cyan")
+    table.add_column("Filename")
+    table.add_column("Source", style="green")
+
+    for item in result.items:
+        table.add_row(item.object_id, item.filename or "-", item.source)
+
+    console.print(table)
 
 
 @app.command()

--- a/vlmrun/client/artifacts.py
+++ b/vlmrun/client/artifacts.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import io
 import requests
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Union
 
 from PIL import Image
 from pydantic import AnyHttpUrl
 
 from vlmrun.client.base_requestor import APIRequestor
+from vlmrun.client.types import ArtifactListResponse
 from vlmrun.common.utils import _HEADERS
 from vlmrun.constants import VLMRUN_ARTIFACTS_CACHE_DIR
 
@@ -33,12 +34,13 @@ class Artifacts:
 
     def get(
         self,
-        object_id: str,
-        session_id: Optional[str] = None,
-        execution_id: Optional[str] = None,
+        object_id: str | None = None,
+        session_id: str | None = None,
+        execution_id: str | None = None,
+        filename: str | None = None,
         raw_response: bool = False,
     ) -> Union[bytes, Image.Image, AnyHttpUrl, Path]:
-        """Get an artifact by session ID or execution ID and object ID.
+        """Get an artifact by session ID or execution ID and object ID or filename.
 
         Supported artifact types:
             - img: Returns PIL.Image.Image (JPEG)
@@ -49,16 +51,20 @@ class Artifacts:
             - recon: Returns Path to SPZ file
 
         Args:
-            object_id: Object ID for the artifact (format: <type>_<6-hex-chars>)
+            object_id: Object ID for the artifact (format: <type>_<6-hex-chars>).
+                Mutually exclusive with filename.
             session_id: Session ID for the artifact (mutually exclusive with execution_id)
             execution_id: Execution ID for the artifact (mutually exclusive with session_id)
+            filename: Workspace or manifest filename to retrieve. Mutually exclusive
+                with object_id.
             raw_response: Whether to return the raw response bytes
 
         Returns:
             The artifact content - type depends on object_id prefix and raw_response flag
 
         Raises:
-            ValueError: If neither session_id nor execution_id is provided, or if both are provided
+            ValueError: If neither session_id nor execution_id is provided, or if both are provided,
+                or if neither object_id nor filename is provided, or if both are provided.
         """
         if session_id is None and execution_id is None:
             raise ValueError("Either `session_id` or `execution_id` is required")
@@ -66,9 +72,19 @@ class Artifacts:
             raise ValueError(
                 "Only one of `session_id` or `execution_id` is allowed, not both"
             )
+        if object_id is None and filename is None:
+            raise ValueError("Either `object_id` or `filename` is required")
+        if object_id is not None and filename is not None:
+            raise ValueError(
+                "Only one of `object_id` or `filename` is allowed, not both"
+            )
 
         # Build query parameters, filtering out None values
-        query_params = {"object_id": object_id}
+        query_params: dict[str, str] = {}
+        if object_id is not None:
+            query_params["object_id"] = object_id
+        if filename is not None:
+            query_params["filename"] = filename
         if session_id is not None:
             query_params["session_id"] = session_id
         if execution_id is not None:
@@ -86,6 +102,10 @@ class Artifacts:
 
         # If raw response is requested, return the raw response as bytes
         if raw_response:
+            return response
+
+        # If filename was used instead of object_id, return raw bytes
+        if object_id is None:
             return response
 
         # Otherwise, return the appropriate type based on the content type
@@ -159,13 +179,39 @@ class Artifacts:
         else:
             return response
 
-    def list(self, session_id: str) -> None:
-        """List artifacts for a session.
+    def list(
+        self,
+        session_id: str | None = None,
+        execution_id: str | None = None,
+    ) -> ArtifactListResponse:
+        """List artifacts for a session or execution.
 
         Args:
-            session_id: Session ID to list artifacts for
+            session_id: Session ID to list artifacts for (mutually exclusive with execution_id)
+            execution_id: Execution ID to list artifacts for (mutually exclusive with session_id)
+
+        Returns:
+            ArtifactListResponse containing the namespace ID and list of artifact items.
 
         Raises:
-            NotImplementedError: This method is not yet implemented
+            ValueError: If neither session_id nor execution_id is provided, or if both are provided.
         """
-        raise NotImplementedError("Artifacts.list() is not yet implemented")
+        if session_id is None and execution_id is None:
+            raise ValueError("Either `session_id` or `execution_id` is required")
+        if session_id is not None and execution_id is not None:
+            raise ValueError(
+                "Only one of `session_id` or `execution_id` is allowed, not both"
+            )
+
+        query_params: dict[str, str] = {}
+        if session_id is not None:
+            query_params["session_id"] = session_id
+        if execution_id is not None:
+            query_params["execution_id"] = execution_id
+
+        response, _, _ = self._requestor.request(
+            method="GET",
+            url="artifacts/list",
+            params=query_params,
+        )
+        return ArtifactListResponse.model_validate(response)

--- a/vlmrun/client/types.py
+++ b/vlmrun/client/types.py
@@ -239,16 +239,18 @@ class AgentExecutionOrCreationConfig(BaseModel):
         default=None,
         description="List of agent skills to enable for this execution. Skills provide domain-specific expertise and capabilities.",
     )
-    service_tier: Literal["auto", "default", "standard", "flex", "priority"] | None = Field(
-        default=None,
-        description=(
-            "Delivery tier mirroring OpenAI's service_tier and Vertex AI's "
-            "Gemini Flex/Priority offering. 'standard'/'default' uses baseline "
-            "rates, 'flex' applies a 50% discount with higher latency, "
-            "'priority' applies a 1.8x premium. When omitted (or 'auto'), the "
-            "server default applies (which itself defaults to 'standard'). The "
-            "chosen tier drives BOTH billing AND the actual request routing."
-        ),
+    service_tier: Literal["auto", "default", "standard", "flex", "priority"] | None = (
+        Field(
+            default=None,
+            description=(
+                "Delivery tier mirroring OpenAI's service_tier and Vertex AI's "
+                "Gemini Flex/Priority offering. 'standard'/'default' uses baseline "
+                "rates, 'flex' applies a 50% discount with higher latency, "
+                "'priority' applies a 1.8x premium. When omitted (or 'auto'), the "
+                "server default applies (which itself defaults to 'standard'). The "
+                "chosen tier drives BOTH billing AND the actual request routing."
+            ),
+        )
     )
 
     @model_validator(mode="after")
@@ -326,6 +328,29 @@ class AgentCreationResponse(BaseModel):
         ..., description="Date and time when the agent was updated (in UTC timezone)"
     )
     status: JobStatus = Field(..., description="The status of the agent")
+
+
+ArtifactSource = Literal["store", "manifest", "workspace"]
+
+
+class ArtifactListItem(BaseModel):
+    """A single artifact entry returned by the list endpoint."""
+
+    object_id: str = Field(..., description="Artifact object ID for GET /v1/artifacts")
+    filename: str | None = Field(
+        None,
+        description="Workspace or manifest filename; also accepted as GET /v1/artifacts?filename=...",
+    )
+    source: ArtifactSource = Field(..., description="store, manifest, or workspace")
+
+
+class ArtifactListResponse(BaseModel):
+    """Response from the artifacts list endpoint."""
+
+    namespace_id: str = Field(..., description="Session or execution namespace ID")
+    items: list[ArtifactListItem] = Field(
+        default_factory=list, description="Artifact entries in the namespace"
+    )
 
 
 class SkillInfo(BaseModel):
@@ -608,16 +633,18 @@ class GenerationConfig(BaseModel):
         default=None,
         description="0-indexed page indices to process for document files. If None, all pages are processed.",
     )
-    service_tier: Literal["auto", "default", "standard", "flex", "priority"] | None = Field(
-        default=None,
-        description=(
-            "Delivery tier mirroring OpenAI's service_tier and Vertex AI's "
-            "Gemini Flex/Priority offering. 'standard'/'default' uses baseline "
-            "rates, 'flex' applies a 50% discount with higher latency, "
-            "'priority' applies a 1.8x premium. When omitted (or 'auto'), the "
-            "server default applies (which itself defaults to 'standard'). The "
-            "chosen tier drives BOTH billing AND the actual request routing."
-        ),
+    service_tier: Literal["auto", "default", "standard", "flex", "priority"] | None = (
+        Field(
+            default=None,
+            description=(
+                "Delivery tier mirroring OpenAI's service_tier and Vertex AI's "
+                "Gemini Flex/Priority offering. 'standard'/'default' uses baseline "
+                "rates, 'flex' applies a 50% discount with higher latency, "
+                "'priority' applies a 1.8x premium. When omitted (or 'auto'), the "
+                "server default applies (which itself defaults to 'standard'). The "
+                "chosen tier drives BOTH billing AND the actual request routing."
+            ),
+        )
     )
     skills: Optional[List["AgentSkill"]] = Field(
         default=None,


### PR DESCRIPTION
## Summary

Adds SDK support for the new `GET /v1/artifacts/list` endpoint (vlm-lab PR #2001) and extends `artifacts.get()` to accept a `filename` parameter.

**New types** in `vlmrun/client/types.py`:
```python
ArtifactSource = Literal["store", "manifest", "workspace"]

class ArtifactListItem(BaseModel):
    object_id: str
    filename: str | None
    source: ArtifactSource

class ArtifactListResponse(BaseModel):
    namespace_id: str
    items: list[ArtifactListItem]
```

**`Artifacts.get()`** — new optional `filename` parameter (mutually exclusive with `object_id`):
```python
client.artifacts.get(filename="report.pdf", session_id="...")
```

**`Artifacts.list()`** — calls `GET /v1/artifacts/list` with `session_id` or `execution_id`:
```python
response = client.artifacts.list(session_id="...")
for item in response.items:
    print(item.object_id, item.filename, item.source)
```

**CLI** — new `vlmrun artifacts list --session-id <id>` subcommand with rich table output.

Tests cover all new paths including mutual-exclusivity validation for both `get()` and `list()`.

Link to Devin session: https://app.devin.ai/sessions/13d55013533b4c8d826104e377b2cabb
Requested by: @dineshreddy91
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-python-sdk/pull/197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->