### PR TITLE
feat(types): expose USD cost/tier fields on CreditUsage

### DIFF
--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -600,3 +600,57 @@ def test_generation_config_service_tier_invalid():
 
     with pytest.raises(ValidationError):
         GenerationConfig(service_tier="ultra")
+
+
+def test_credit_usage_dollar_fields_parsed_from_api_payload():
+    """CreditUsage exposes the dollar/tier fields returned by the API."""
+    usage = CreditUsage.model_validate(
+        {
+            "elements_processed": 1,
+            "element_type": "page",
+            "credits_used": 50,
+            "duration_seconds": 2,
+            "service_tier": "flex",
+            "mode_multiplier": 0.5,
+            "standard_cost_dollars": 1.0,
+            "cost_dollars": 0.5,
+            "savings_dollars": 0.5,
+        }
+    )
+    assert usage.service_tier == "flex"
+    assert usage.mode_multiplier == 0.5
+    assert usage.standard_cost_dollars == 1.0
+    assert usage.cost_dollars == 0.5
+    assert usage.savings_dollars == 0.5
+
+
+def test_credit_usage_dollar_fields_default_none():
+    """Dollar/tier fields default to None when omitted by the API."""
+    usage = CreditUsage(credits_used=100)
+    assert usage.service_tier is None
+    assert usage.mode_multiplier is None
+    assert usage.standard_cost_dollars is None
+    assert usage.cost_dollars is None
+    assert usage.savings_dollars is None
+
+
+def test_prediction_response_retains_usage_dollar_fields():
+    """PredictionResponse round-trips the dollar/tier usage fields."""
+    response = PredictionResponse(
+        id="pred1",
+        status="completed",
+        created_at="2024-01-01T00:00:00+00:00",
+        completed_at="2024-01-01T00:00:01+00:00",
+        response={"invoice_number": "INV-001", "total_amount": 100.0},
+        usage=CreditUsage(
+            credits_used=50,
+            service_tier="flex",
+            mode_multiplier=0.5,
+            standard_cost_dollars=1.0,
+            cost_dollars=0.5,
+            savings_dollars=0.5,
+        ),
+    )
+    assert response.usage.cost_dollars == 0.5
+    assert response.usage.savings_dollars == 0.5
+    assert response.model_dump()["usage"]["cost_dollars"] == 0.5

--- a/vlmrun/client/types.py
+++ b/vlmrun/client/types.py
@@ -76,11 +76,11 @@ class CreditUsage(BaseModel):
     steps: Optional[int] = None
     message: Optional[str] = None
     duration_seconds: int = 0
-    service_tier: Optional[str] = None
-    mode_multiplier: Optional[float] = None
-    standard_cost_dollars: Optional[float] = None
-    cost_dollars: Optional[float] = None
-    savings_dollars: Optional[float] = None
+    service_tier: str | None = None
+    mode_multiplier: float | None = None
+    standard_cost_dollars: float | None = None
+    cost_dollars: float | None = None
+    savings_dollars: float | None = None
 
 
 class PredictionResponse(BaseModel):

--- a/vlmrun/client/types.py
+++ b/vlmrun/client/types.py
@@ -76,6 +76,11 @@ class CreditUsage(BaseModel):
     steps: Optional[int] = None
     message: Optional[str] = None
     duration_seconds: int = 0
+    service_tier: Optional[str] = None
+    mode_multiplier: Optional[float] = None
+    standard_cost_dollars: Optional[float] = None
+    cost_dollars: Optional[float] = None
+    savings_dollars: Optional[float] = None
 
 
 class PredictionResponse(BaseModel):


### PR DESCRIPTION
## Summary

The VLM Run API returns per-request USD cost + service-tier info inside the `usage` object of prediction/execution responses (`CreditUsageResponse` in vlm-lab, populated in `vlm/infra/cloud/billing/usage.py`), but the SDK's `CreditUsage` model only declared the credit fields — so Pydantic silently dropped the dollar fields and `response.usage.cost_dollars` was inaccessible.

This adds the 5 wire fields to `CreditUsage` so they round-trip:

```diff
 class CreditUsage(BaseModel):
     elements_processed: Optional[int] = None
     element_type: Optional[Literal["image", "page", "video", "audio"]] = None
     credits_used: Optional[int] = None
     steps: Optional[int] = None
     message: Optional[str] = None
     duration_seconds: int = 0
+    service_tier: Optional[str] = None
+    mode_multiplier: Optional[float] = None
+    standard_cost_dollars: Optional[float] = None
+    cost_dollars: Optional[float] = None
+    savings_dollars: Optional[float] = None
```

These mirror exactly the non-excluded fields of the API's `CreditUsageResponse`. The API's `input_tokens` / `output_tokens` / `credit_cost_dollars` are intentionally **not** added — they are `exclude=True` on the server (internal-only, not on the wire).

Applies to both `PredictionResponse.usage` and `AgentExecutionResponse.usage` (both typed as `CreditUsage`).

```python
resp = client.image.generate(domain="document.invoice", urls=[...])
resp.usage.cost_dollars      # effective USD charged
resp.usage.standard_cost_dollars
resp.usage.savings_dollars   # discount on flex tier
resp.usage.service_tier      # "standard" | "flex" | "priority"
```

## Test plan
- Added tests in `tests/test_predictions.py` covering parse-from-payload, default-`None`, and `PredictionResponse` round-trip of the new fields.
- `pytest tests/test_predictions.py tests/test_agent.py` → 79 passed.
- `pre-commit run` (ruff + black) → passed.

Companion Node SDK PR: vlm-run/vlmrun-node-sdk (same fields on the `CreditUsage` interface).

Link to Devin session: https://app.devin.ai/sessions/af66c3426c7f41188105bcaff4defc1b
Requested by: @jeremyipark
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-python-sdk/pull/202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->